### PR TITLE
Update codegen for 2018-07-16 nightly.

### DIFF
--- a/codegen/build.rs
+++ b/codegen/build.rs
@@ -5,8 +5,8 @@ use yansi::Color::{Red, Yellow, Blue, White};
 use version_check::{supports_features, is_min_version, is_min_date};
 
 // Specifies the minimum nightly version needed to compile Pear.
-const MIN_DATE: &'static str = "2018-04-14";
-const MIN_VERSION: &'static str = "1.27.0-nightly";
+const MIN_DATE: &'static str = "2018-07-16";
+const MIN_VERSION: &'static str = "1.29.0-nightly";
 
 fn main() {
     let ok_channel = supports_features();

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -1,6 +1,5 @@
-#![feature(proc_macro)]
 #![feature(core_intrinsics)]
-#![feature(proc_macro_non_items)]
+#![feature(proc_macro_diagnostic, proc_macro_span)]
 #![recursion_limit="256"]
 
 extern crate proc_macro;

--- a/examples/ini/src/main.rs
+++ b/examples/ini/src/main.rs
@@ -1,5 +1,4 @@
-#![feature(proc_macro)]
-#![feature(proc_macro_non_items)]
+#![feature(proc_macro_non_items, use_extern_macros)]
 
 #[macro_use] extern crate pear;
 

--- a/examples/json/src/main.rs
+++ b/examples/json/src/main.rs
@@ -1,5 +1,4 @@
-#![feature(proc_macro)]
-#![feature(proc_macro_non_items)]
+#![feature(proc_macro_non_items, use_extern_macros)]
 
 #[macro_use] extern crate pear;
 

--- a/examples/media_type/src/main.rs
+++ b/examples/media_type/src/main.rs
@@ -1,5 +1,4 @@
-#![feature(proc_macro)]
-#![feature(proc_macro_non_items)]
+#![feature(proc_macro_non_items, use_extern_macros)]
 
 #[macro_use] extern crate pear;
 

--- a/examples/parens/src/main.rs
+++ b/examples/parens/src/main.rs
@@ -1,5 +1,4 @@
-#![feature(proc_macro)]
-#![feature(proc_macro_non_items)]
+#![feature(proc_macro_non_items, use_extern_macros)]
 
 #[macro_use] extern crate pear;
 extern crate time;

--- a/examples/uri/src/lib.rs
+++ b/examples/uri/src/lib.rs
@@ -1,5 +1,4 @@
-#![feature(proc_macro)]
-#![feature(proc_macro_non_items)]
+#![feature(proc_macro_non_items, use_extern_macros)]
 #![allow(unused_imports, dead_code)]
 
 #[macro_use] extern crate pear;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,6 +1,5 @@
-#![feature(proc_macro)]
 #![feature(core_intrinsics)]
-#![feature(proc_macro_non_items)]
+#![feature(proc_macro_non_items, use_extern_macros)]
 #![feature(specialization)]
 
 #[allow(unused_imports)] #[macro_use] extern crate pear_codegen;


### PR DESCRIPTION
`proc_macro` partially stabilized and also split into `proc_macro_diagnostic`, `proc_macro_span`, `use_extern_macros`.