### PR TITLE
Update yansi to 0.5

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -14,5 +14,5 @@ proc-macro2 = { version = "0.4", features = ["nightly"] }
 syn = { version = "0.15", features = ["full", "extra-traits", "visit-mut"] }
 
 [build-dependencies]
-yansi = "0.4"
+yansi = "0.5"
 version_check = "0.1.3"


### PR DESCRIPTION
Rocket itself depends on yansi 0.5, so this eliminates having multiple
versions in the dependency tree, and probably shaves a second off of a
clean build.