### PR TITLE
update yansi to 0.5

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-yansi = { version = "0.4", optional = true }
+yansi = { version = "0.5", optional = true }
 pear_codegen = { version = "0.2.0-dev", path = "../codegen" }
 
 [features]


### PR DESCRIPTION
Rocket itself depends on yansi 0.5 so this fixes having duplicate crate versions.

I see something was already done in #15 but I'm not sure what happened with that since Pear is still using yansi 0.4