### PR TITLE
Added repository link to crate metadata

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Sergio Benitez <sb@sergio.bz>"]
 description = "A (codegen) pear is a fruit."
 license = "MIT/Apache-2.0"
 edition = "2018"
+repository = "https://github.com/SergioBenitez/Pear"
 
 [lib]
 proc-macro = true

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Sergio Benitez <sb@sergio.bz>"]
 description = "A pear is a fruit."
 license = "MIT/Apache-2.0"
 edition = "2018"
+repository = "https://github.com/SergioBenitez/Pear"
 
 [dependencies]
 yansi = { version = "0.4", optional = true }


### PR DESCRIPTION
It was a bit difficult to find this Git repository from crates.io. It would be nice to have the link directly, so that we can point here if we want to contribute.

Still, the README seems to imply that this should be secret? It's being used by Rocket, so I think it should be easy to audit/maintain.