### PR TITLE
Upgraded dependencies

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -11,7 +11,7 @@ proc-macro = true
 
 [dependencies]
 quote = "1.0"
-proc-macro2 = { version = "1.0" }
+proc-macro2 = "1.0"
 syn = { version = "1.0", features = ["full", "extra-traits", "visit-mut"] }
 
 [build-dependencies]

--- a/examples/ini/Cargo.toml
+++ b/examples/ini/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 pear = { path = "../../lib" }
-time = "0.1"
+time = "0.2"

--- a/examples/parens/Cargo.toml
+++ b/examples/parens/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 [dependencies]
 pear = { path = "../../lib" }
 pear_codegen = { path = "../../codegen" }
-time = "0.1"
+time = "0.2"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-yansi = { version = "0.4", optional = true }
+yansi = { version = "0.5", optional = true }
 pear_codegen = { version = "0.2.0-dev", path = "../codegen" }
 
 [features]


### PR DESCRIPTION
I upgraded the dependencies of the library. Especially the `yansi` dependency that was (I think mistakenly) closed in #15. This also includes #19 

Would it be possible to publish an updated version in crates.io? That way we would avoid duplicated dependencies using Rocket.