### PR TITLE
Don't use `unwrap` after calling `Span.join`

### DIFF
--- a/codegen/src/parser.rs
+++ b/codegen/src/parser.rs
@@ -106,7 +106,7 @@ impl syn::parse::Parse for CallPattern {
 impl Spanned for CallPattern {
     fn span(&self) -> Span {
         match self.name {
-            Some(ref name) => name.span().unstable().join(self.expr.span()).unwrap(),
+            Some(ref name) => name.span().unstable().join(self.expr.span()).unwrap_or_else(|| self.expr.span()),
             None => self.expr.span()
         }
     }
@@ -207,7 +207,7 @@ impl Parse for Case {
         pattern.validate()?;
         input.parse::<Token![=>]>()?;
         let expr: syn::Expr = input.parse()?;
-        let span = case_span_start.join(input.cursor().span().unstable()).unwrap();
+        let span = case_span_start.join(input.cursor().span().unstable()).unwrap_or(case_span_start);
 
         Ok(Case { pattern, expr, span })
     }


### PR DESCRIPTION
The method `Span.join` will return `None` if the start and end `Span`s
are from different files. This is currently difficult to observe in
practice due to rust-lang/rust#43081, which causes span information
(including file information) to be lost in many cases.

However, PR rust-lang/rust#73084 will cause `Spans` to be properly
preserved in many more cases. This will cause `rocket` to to stop
compiling, as this code will end up getting hit with spans from
different files (one from rocket, and one from the `result` ident
defined in the `pear_try!` macro.

To reproduce the issue:

1. Checkout SergioBenitez/Rocket#63a4ae048540a6232c3c7c186e9d027081940382
2. Install https://github.com/kennytm/rustup-toolchain-install-master if
   you don't already have it
3. Run `rustup-toolchain-install-master 879b8cb7dc2ad9102994457e73cf78d124926ea5`
   (this corresponds to the latest commit from rust-lang/rust#73084)
4. From the `Rocket` checkout, run `cargo +879b8cb7dc2ad9102994457e73cf78d124926ea5 build`
5. Observe the panic from `Pear`

I've based this PR on the commit for `Pear 0.1.2`, since the master
branch has many breaking changes. I would recommend merging this change
into a separate branch, and making a new `0.1.3` point release.