### PR TITLE
Draft: Remove all feature gates 

### DIFF
--- a/examples/group/src/main.rs
+++ b/examples/group/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(proc_macro_hygiene)]
 #![warn(rust_2018_idioms)]
 
 use pear::macros::{parser, switch, parse};

--- a/examples/ini/src/main.rs
+++ b/examples/ini/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(proc_macro_hygiene)]
 #![warn(rust_2018_idioms)]
 
 use std::fmt;

--- a/examples/json/src/main.rs
+++ b/examples/json/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(proc_macro_hygiene)]
 #![warn(rust_2018_idioms)]
 
 use std::collections::HashMap;

--- a/examples/parens/src/main.rs
+++ b/examples/parens/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(proc_macro_hygiene)]
 #![warn(rust_2018_idioms)]
 
 use pear::input::{Text, Result};

--- a/lib/src/input/string.rs
+++ b/lib/src/input/string.rs
@@ -1,7 +1,5 @@
 pub use crate::input::{Input, Token, Slice, ParserInfo};
 
-impl<'a, 'b: 'a> Slice<&'a str> for &'b str { }
-
 // ident_impl_token!(&str);
 
 impl<'a> Input for &'a str {

--- a/lib/src/input/text.rs
+++ b/lib/src/input/text.rs
@@ -42,8 +42,6 @@ impl<'a> From<&'a str> for Text<'a> {
     }
 }
 
-impl<'a, 'b> Slice<Text<'a>> for &'b str { }
-
 // ident_impl_token!(Text<'_>);
 
 impl Rewind for Text<'_> {

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,6 +1,3 @@
-#![feature(proc_macro_hygiene)]
-#![feature(specialization)]
-
 #![warn(rust_2018_idioms)]
 
 #[macro_use] pub mod macros;

--- a/lib/tests/parsers.rs
+++ b/lib/tests/parsers.rs
@@ -11,7 +11,7 @@ fn take_until_str<'a>(input: &mut Text<'a>, s: &str) -> Result<'a, &'a str> {
 }
 
 #[parser]
-fn test_until<'a>(input: &mut Text<'a>, s: &str, r: &str) -> Result<'a, &'a str> {
+fn test_until<'a>(input: &mut Text<'a>, s: &str, r: &'a str) -> Result<'a, &'a str> {
     (take_until_str(s)?, eat_slice(r)?).0
 }
 
@@ -43,7 +43,7 @@ fn take_until_and_str<'a>(input: &mut Text<'a>, s: &str) -> Result<'a, &'a str> 
 }
 
 #[parser]
-fn test_until_and<'a>(input: &mut Text<'a>, s: &str, r: &str) -> Result<'a, &'a str> {
+fn test_until_and<'a>(input: &mut Text<'a>, s: &'a str, r: &'a str) -> Result<'a, &'a str> {
     (take_until_and_str(s)?, eat_slice(r)?).0
 }
 
@@ -69,7 +69,7 @@ fn test_while_slice_and() {
 }
 
 #[parser]
-fn test_until_window<'a>(input: &mut Text<'a>, s: &str, r: &str) -> Result<'a, &'a str> {
+fn test_until_window<'a>(input: &mut Text<'a>, s: &'a str, r: &'a str) -> Result<'a, &'a str> {
     (take_until_slice(s)?, eat_slice(r)?).0
 }
 


### PR DESCRIPTION
I've created a branch that requires no feature gates and compiles for the most part on beta. 

The only remaining nightly-only functionality is Span.join which is nightly only: https://doc.rust-lang.org/proc_macro/struct.Span.html#method.join . Open issue is https://github.com/rust-lang/rust/issues/54725

All macro compiles panic on https://github.com/SergioBenitez/Pear/blob/master/codegen/src/parser.rs#L168

