### PR TITLE
Correct inlinable_string version requirement

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 yansi = { version = "0.5", optional = true }
 pear_codegen = { version = "0.2.3", path = "../codegen" }
-inlinable_string = "0.1"
+inlinable_string = "0.1.9"
 
 [features]
 default = ["color"]


### PR DESCRIPTION
Pear is using `Write` implementation that was introduced in 0.1.9. This commit fixes version requirement to be actually correct. This helps with `cargo update -Z minimal-versions` builds (https://github.com/rust-lang/cargo/issues/5657).